### PR TITLE
Use yarn instead of npm to run prettier

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -46,7 +46,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "format": "npm run prettier -- --write '{,!(build|generators)/**/}*.js'",
+    "format": "yarn run prettier -- --write '{,!(build|generators)/**/}*.js'",
     "precommit": "lint-staged",
     "eslint-check":
       "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
@@ -55,7 +55,7 @@
     "generate": "plop --plopfile generators/index.js"
   },
   "lint-staged": {
-    "{,!(build|generators)/**/}*.js": ["npm run prettier -- --write", "git add"]
+    "{,!(build|generators)/**/}*.js": ["yarn run prettier -- --write", "git add"]
   },
   "engines": {
     "npm": ">=4",


### PR DESCRIPTION
Otherwise attempted commits fail:
 ❯ Running tasks for {,!(build|generators)/**/}*.js
   ✖ npm run prettier -- --write
     → ✖ npm run prettier -- --write found some errors. Please fix them and try committing again.

Running `npm run prettier` manually shows that it is not installed:

> $ npm run prettier
> npm ERR! missing script: prettier

It works with `yarn run prettier`, since yarn installed the dependencies.